### PR TITLE
Fix a bug causing crashiness

### DIFF
--- a/butane.rb
+++ b/butane.rb
@@ -4,6 +4,7 @@ require 'tinder'
 require 'yaml'
 
 def notify(title, message = "", options = {})
+  return if message.nil?
   img_opt = "-i #{options[:image]}" if options[:image]
   delay_opt = ""
   if options[:delay]


### PR DESCRIPTION
If message is nil, butane crashes. This change fixes that.
