### PR TITLE
Extend ignore support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,6 +85,7 @@ Fixed keywords in the above:
 * :rooms:
 * :sticky:
 * :ignore:
+* :self_name:
 
 The rest of the items, "mycampfire", "otheraccount", "First Room" and "Git
 Commits", "Light is Nice" are the names of your accounts and rooms in those
@@ -95,6 +96,9 @@ that match that regexp.
 
 For campfire accounts that are ssl-enabled, you'll need to use the :ssl:
 configuration to specify true for such an account.  The default is false.
+
+The :self_name: attribute is a per-account setting that should be your full name
+in the account - your own messages will be filtered out.
 
 The :image: is used for a small 32x32 (or so) image that is used in the
 notification.  This can be done at the account level and/or the room level as

--- a/butane.rb
+++ b/butane.rb
@@ -111,6 +111,7 @@ account_names.each do |account_name|
       if room
         room_configs[room.name] = rooms[room.name] || {}
         room_configs[room.name][:image] ||= account_img
+        room_configs[room.name][:self_name] ||= config[account_name][:self_name]
         tinder_rooms << room
         notify "Now monitoring #{room.name}", "", :image => room_configs[room.name][:image]
       else
@@ -142,7 +143,12 @@ Tinder::Room.listen_to_rooms(tinder_rooms) do |tinder_room, m|
   end
 
   if ignore
-    next if m[:body] =~ /#{ignore}/
+    matched = false
+    ignore.each do |ignore|
+      matched = m[:body] =~ /#{ignore}/
+      break if matched
+    end
+    next if matched
   end
 
   person = m[:user][:name].gsub /"/, ''  # Get rid of any dquotes since we use 'em to delimit person

--- a/butane.rb
+++ b/butane.rb
@@ -144,6 +144,7 @@ Tinder::Room.listen_to_rooms(tinder_rooms) do |tinder_room, m|
   end
 
   if ignore
+    ignore = [ignore].flatten
     next if ignore.any? do |ignore|
       m[:body] =~ /#{ignore}/
     end

--- a/butane.rb
+++ b/butane.rb
@@ -143,15 +143,14 @@ Tinder::Room.listen_to_rooms(tinder_rooms) do |tinder_room, m|
   end
 
   if ignore
-    matched = false
-    ignore.each do |ignore|
-      matched = m[:body] =~ /#{ignore}/
-      break if matched
+    next if ignore.any? do |ignore|
+      m[:body] =~ /#{ignore}/
     end
-    next if matched
   end
 
-  person = m[:user][:name].gsub /"/, ''  # Get rid of any dquotes since we use 'em to delimit person
+  # Get rid of any dquotes since we use 'em to delimit person
+  person = m[:user][:name].gsub /"/, ''
+  next if person.include? room_configs[tinder_room.name][:self_name]
 
   notify("#{person} in #{tinder_room.name}", m[:body], :delay => delay, :image => image)
 end

--- a/butane.rb
+++ b/butane.rb
@@ -134,6 +134,7 @@ Tinder::Room.listen_to_rooms(tinder_rooms) do |tinder_room, m|
   sticky = room_configs[tinder_room.name][:sticky]
   ignore = room_configs[tinder_room.name][:ignore]
   image  = room_configs[tinder_room.name][:image]
+  self_name = room_configs[tinder_room.name][:self_name]
 
   # If we're to monitor something in particular in this room, set the
   # delay notification to zero which will leave the message up until
@@ -150,7 +151,7 @@ Tinder::Room.listen_to_rooms(tinder_rooms) do |tinder_room, m|
 
   # Get rid of any dquotes since we use 'em to delimit person
   person = m[:user][:name].gsub /"/, ''
-  next if person.include? room_configs[tinder_room.name][:self_name]
+  next if self_name and person.include? self_name
 
   notify("#{person} in #{tinder_room.name}", m[:body], :delay => delay, :image => image)
 end


### PR DESCRIPTION
These commits add two things:
- An account-wide setting `:self_name:` that if your user's full display name, will filter out your own messages
- `:ignore:` now optionally accepts a list of patterns
